### PR TITLE
TODO 但输出并不是两个c,两个d，原因？ 解决

### DIFF
--- a/java-multithread/src/main/java/com/brianway/learning/java/multithread/synchronize/example8/TaskB.java
+++ b/java-multithread/src/main/java/com/brianway/learning/java/multithread/synchronize/example8/TaskB.java
@@ -19,7 +19,8 @@ public class TaskB {
                 getData2 = privateGetData2;
                 //System.out.println("切换到线程end："+Thread.currentThread().getName());
             }
-
+            
+            // 不在同步代码块内打印值，值有可能在打印前被另一条线程更改。
             System.out.println(getData1);
             System.out.println(getData2);
             System.out.println("end task");


### PR DESCRIPTION
getData1 and getData2 未在同步代码块内打印，导致打印前被另一线程更改值。